### PR TITLE
Allow socket reuse by isolating sockets inside agents

### DIFF
--- a/src/accession/core.clj
+++ b/src/accession/core.clj
@@ -111,34 +111,59 @@
     (.setTcpNoDelay true)
     (.setKeepAlive true)))
 
+(defn- socket-and-streams
+  [spec]
+  (let [socket (doto (socket spec) (.setSoTimeout (:timeout spec)))
+        in (DataInputStream. (BufferedInputStream. (.getInputStream socket)))
+        out (.getOutputStream socket)]
+    [socket in out spec]))
+
+(defn- close-socket-and-streams
+  [[socket in out _]]
+  (.close socket) (.close in) (.close out))
+
 (def socket-atom (atom {}))
+
+(defn reset-sockets! []
+  (swap! socket-atom (fn [hash]
+                       (doseq [s-and-s (map deref (vals hash))]
+                         (close-socket-and-streams s-and-s))
+                       {})))
 
 (defn- socket-agent
   [spec]
   (when (not (@socket-atom spec))
-    (swap! socket-atom
-           (fn [hash]
-             (assoc hash
-               spec
-               (let [socket (doto (socket spec) (.setSoTimeout (:timeout spec)))
-                     in (DataInputStream. (BufferedInputStream. (.getInputStream socket)))
-                     out (.getOutputStream socket)]
-                 (agent [in out]))))))
+    (swap! socket-atom #(assoc % spec (agent (socket-and-streams spec)))))
   (@socket-atom spec))
 
 (defn request
   "Responsible for actually making the request to the Redis
-  server. Sets the timeout on the socket if one was specified."
+  server. Sets the timeout on the socket if one was specified.
+
+Uses a long lived open socket owned by an agent to execute the request.
+If the socket throws an exception reading or writing, close it and start
+a new one but do not retry the query.
+
+Throwables thrown in the agent will be manually rethrown in the caller
+thread."
   [conn & query]
   (let [p (promise)]
     (send (socket-agent conn)
-          (fn [[in out]]
-            (.write out (.getBytes (apply str query)))
-            (deliver p (if (next query)
-                         (doall (repeatedly (count query) #(response in)))
-                         (response in)))
-            [in out]))
-    @p))
+          (fn [[socket in out spec :as s-and-s]]
+            (try
+              (.write out (.getBytes (apply str query)))
+              (deliver p (if (next query)
+                           (doall (repeatedly (count query) #(response in)))
+                           (response in)))
+              s-and-s
+              (catch Throwable e
+                (deliver p e) (close-socket-and-streams s-and-s)
+                (socket-and-streams spec)))))
+    (let [result (deref p)]
+      ;; this seems potentially slow due to reflection - benchmark, maybe use protocol
+      (if (instance? Throwable result)
+        (throw result)
+        result))))
 
 (defn receive-message
   "Used in conjunction with an open channel to handle messages that


### PR DESCRIPTION
Rather than introducing connection pooling, use agents to enable
socket reuse. Requests are now sent to the socket agent and responses
are returned via a promise.

This currently only supports a single redis socket per connection spec
(ok-ish since redis is single threaded anyway?) but could be easily
expanded to support a pool of socket agents per connection spec.

TODO: deal with socket errors
