### PR TITLE
Add monitor support

### DIFF
--- a/test/accession/test/core.clj
+++ b/test/accession/test/core.clj
@@ -193,6 +193,14 @@
            (redis/lrange "children" "0" "3")
            (redis/get "favorite:child")))))
 
+(deftest test-monitor
+  (let [received (atom (str))
+        monitor (redis/monitor c #(reset! received %))]
+    (redis/with-connection c
+      (redis/ping))
+    (is (= "PING" (re-find #"PING" @received)))
+    (redis/close monitor)))
+
 (deftest test-pubsub
   (let [received (atom [])
         channel (redis/subscribe c {"ps-foo" #(swap! received conj %)})]


### PR DESCRIPTION
Heyo!

This commit adds support for the streaming 'monitor' command. A few things to note:
1. I generalized 'open-channel' to something like 'open-stream' - since both monitoring and subscribing to channels need to open a connection that listens for an unbounded list of responses and pass them to their corresponding callback functions. This uses a multi-method 'stream-record' to build the record based on the type (:monitor or :channel).
2. I tried renaming "RedisChannel" to "RedisStream" and implementing the monitor and pub/sub protocols, but having one record that represented both a pub/sub metaphor (where you can add and remove subscriptions) and a monitor metaphor (where you can start and stop the monitor) made interaction with the record more confusing. I chose to break these concepts apart instead.
3. I renamed "IRedisChannel" to "IRedisClosable" since both a monitor and channel record should implement close functionality.

Feedback is much appreciated, thanks!

Blake
